### PR TITLE
harden: negative fixtures + M3 (schemas must reject malformed manifests)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,3 +21,5 @@ jobs:
         run: make smoke
       - name: Strict jsonschema validation of maturity record
         run: python3 tools/validate_maturity.py schemas/repo-maturity.schema.json repo.maturity.yaml
+      - name: Negative fixtures (must be rejected)
+        run: python3 tools/run_negative_fixtures.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: validate validate-spine smoke carry
+.PHONY: validate validate-spine validate-negative smoke carry
 
 validate: validate-spine
 	python3 tools/validate.py
@@ -11,3 +11,6 @@ smoke:
 
 carry:
 	python3 tools/emit_sourceos_carry.py > examples/sourceos-carry.timeserieslab.json
+
+validate-negative:
+	python3 tools/run_negative_fixtures.py

--- a/fixtures/invalid/functional-service.bad-function.json
+++ b/fixtures/invalid/functional-service.bad-function.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": "functional-service.v1",
+  "service": {
+    "id": "timeserieslab.holmes.timeseries-pilot",
+    "name": "TimeSeriesLab Holmes TimeSeries Pilot",
+    "ownerRepository": "SociOS-Linux/timeserieslab",
+    "status": "experimental",
+    "description": "Offline deterministic timeseries functional surface emitted by timeserieslab for governed promotion."
+  },
+  "function": "not-a-real-function",
+  "model": {
+    "modelRef": "urn:socioprophet:functional-model:timeserieslab:deterministic-timeseries:v0",
+    "adapterRefs": [],
+    "runtime": "python-stdlib-offline-smoke",
+    "mutableStatePolicy": "forbidden-in-sourceos"
+  },
+  "inputs": [
+    "series/query",
+    "series/corpus"
+  ],
+  "outputs": [
+    "timeseries/features",
+    "ranking/candidates",
+    "evidence/smoke-receipt"
+  ],
+  "evals": {
+    "required": true,
+    "references": [
+      "examples/smoke-input.json",
+      "examples/smoke-output.json",
+      "evidence/smoke-receipt.example.json"
+    ],
+    "minimumPromotionGate": "candidate requires signed eval and dataset provenance"
+  },
+  "governance": {
+    "ledgerRequired": true,
+    "guardrailRequired": true,
+    "routingRequired": true,
+    "policyRefs": [
+      "SocioProphet/model-governance-ledger",
+      "SocioProphet/guardrail-fabric",
+      "SocioProphet/model-router",
+      "SocioProphet/holmes"
+    ]
+  },
+  "sourceosCarry": {
+    "allowed": true,
+    "carriesMutableModelState": false,
+    "clientRefRequired": true,
+    "launchProfileRefs": [
+      "urn:srcos:model-carry:functional-service:timeserieslab-holmes-pilot"
+    ]
+  }
+}

--- a/fixtures/invalid/functional-service.missing-schema-version.json
+++ b/fixtures/invalid/functional-service.missing-schema-version.json
@@ -1,0 +1,53 @@
+{
+  "service": {
+    "id": "timeserieslab.holmes.timeseries-pilot",
+    "name": "TimeSeriesLab Holmes TimeSeries Pilot",
+    "ownerRepository": "SociOS-Linux/timeserieslab",
+    "status": "experimental",
+    "description": "Offline deterministic timeseries functional surface emitted by timeserieslab for governed promotion."
+  },
+  "function": "timeseries",
+  "model": {
+    "modelRef": "urn:socioprophet:functional-model:timeserieslab:deterministic-timeseries:v0",
+    "adapterRefs": [],
+    "runtime": "python-stdlib-offline-smoke",
+    "mutableStatePolicy": "forbidden-in-sourceos"
+  },
+  "inputs": [
+    "series/query",
+    "series/corpus"
+  ],
+  "outputs": [
+    "timeseries/features",
+    "ranking/candidates",
+    "evidence/smoke-receipt"
+  ],
+  "evals": {
+    "required": true,
+    "references": [
+      "examples/smoke-input.json",
+      "examples/smoke-output.json",
+      "evidence/smoke-receipt.example.json"
+    ],
+    "minimumPromotionGate": "candidate requires signed eval and dataset provenance"
+  },
+  "governance": {
+    "ledgerRequired": true,
+    "guardrailRequired": true,
+    "routingRequired": true,
+    "policyRefs": [
+      "SocioProphet/model-governance-ledger",
+      "SocioProphet/guardrail-fabric",
+      "SocioProphet/model-router",
+      "SocioProphet/holmes"
+    ]
+  },
+  "sourceosCarry": {
+    "allowed": true,
+    "carriesMutableModelState": false,
+    "clientRefRequired": true,
+    "launchProfileRefs": [
+      "urn:srcos:model-carry:functional-service:timeserieslab-holmes-pilot"
+    ]
+  }
+}

--- a/fixtures/invalid/functional-service.mutable-carry.json
+++ b/fixtures/invalid/functional-service.mutable-carry.json
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": "functional-service.v1",
+  "service": {
+    "id": "timeserieslab.holmes.timeseries-pilot",
+    "name": "TimeSeriesLab Holmes TimeSeries Pilot",
+    "ownerRepository": "SociOS-Linux/timeserieslab",
+    "status": "experimental",
+    "description": "Offline deterministic timeseries functional surface emitted by timeserieslab for governed promotion."
+  },
+  "function": "timeseries",
+  "model": {
+    "modelRef": "urn:socioprophet:functional-model:timeserieslab:deterministic-timeseries:v0",
+    "adapterRefs": [],
+    "runtime": "python-stdlib-offline-smoke",
+    "mutableStatePolicy": "forbidden-in-sourceos"
+  },
+  "inputs": [
+    "series/query",
+    "series/corpus"
+  ],
+  "outputs": [
+    "timeseries/features",
+    "ranking/candidates",
+    "evidence/smoke-receipt"
+  ],
+  "evals": {
+    "required": true,
+    "references": [
+      "examples/smoke-input.json",
+      "examples/smoke-output.json",
+      "evidence/smoke-receipt.example.json"
+    ],
+    "minimumPromotionGate": "candidate requires signed eval and dataset provenance"
+  },
+  "governance": {
+    "ledgerRequired": true,
+    "guardrailRequired": true,
+    "routingRequired": true,
+    "policyRefs": [
+      "SocioProphet/model-governance-ledger",
+      "SocioProphet/guardrail-fabric",
+      "SocioProphet/model-router",
+      "SocioProphet/holmes"
+    ]
+  },
+  "sourceosCarry": {
+    "allowed": true,
+    "carriesMutableModelState": true,
+    "clientRefRequired": true,
+    "launchProfileRefs": [
+      "urn:srcos:model-carry:functional-service:timeserieslab-holmes-pilot"
+    ]
+  }
+}

--- a/fixtures/invalid/maturity.empty-owners.yaml
+++ b/fixtures/invalid/maturity.empty-owners.yaml
@@ -3,18 +3,16 @@ repository: SociOS-Linux/timeserieslab
 plane: socios-lab
 status: experimental
 canonicality: reference
-owners:
-  - SociOS-Linux
+owners: []
 maturity:
-  level: M3
-  targetLevel: M4
+  level: M2
+  targetLevel: M3
   evidence:
     - README.md states lab purpose, lab-only boundary, and integration points.
     - service-manifest/functional-service.v1.json conforms to functional-service.v1.
     - lab.manifest.json enumerates 4 governed lab surfaces.
     - make validate exits 0 (offline, deterministic).
     - CI runs make validate + strict jsonschema validation on every push/PR.
-    - Negative fixtures under fixtures/invalid/ confirm the schemas reject malformed documents (CI-enforced).
 validation:
   commands:
     - make validate
@@ -44,5 +42,6 @@ integrations:
     relationship: disabled-by-default SourceOS carry reference
     required: false
 nextActions:
-  - Produce tagged releases with sha256 checksums / provenance attestation (M4).
+  - Add negative fixtures under fixtures/invalid/ (>=2 per schema) to reach M3.
+  - Wire promotion evidence into SocioProphet/model-governance-ledger.
   - Register maturity record with SocioProphet/sociosphere workspace-inventory.

--- a/fixtures/invalid/maturity.invalid-level.yaml
+++ b/fixtures/invalid/maturity.invalid-level.yaml
@@ -6,15 +6,14 @@ canonicality: reference
 owners:
   - SociOS-Linux
 maturity:
-  level: M3
-  targetLevel: M4
+  level: M9
+  targetLevel: M3
   evidence:
     - README.md states lab purpose, lab-only boundary, and integration points.
     - service-manifest/functional-service.v1.json conforms to functional-service.v1.
     - lab.manifest.json enumerates 4 governed lab surfaces.
     - make validate exits 0 (offline, deterministic).
     - CI runs make validate + strict jsonschema validation on every push/PR.
-    - Negative fixtures under fixtures/invalid/ confirm the schemas reject malformed documents (CI-enforced).
 validation:
   commands:
     - make validate
@@ -44,5 +43,6 @@ integrations:
     relationship: disabled-by-default SourceOS carry reference
     required: false
 nextActions:
-  - Produce tagged releases with sha256 checksums / provenance attestation (M4).
+  - Add negative fixtures under fixtures/invalid/ (>=2 per schema) to reach M3.
+  - Wire promotion evidence into SocioProphet/model-governance-ledger.
   - Register maturity record with SocioProphet/sociosphere workspace-inventory.

--- a/tools/run_negative_fixtures.py
+++ b/tools/run_negative_fixtures.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""M3 negative-fixture runner: every fixture under fixtures/invalid/ MUST be rejected
+by its schema. Exits non-zero if any invalid document unexpectedly validates — that would
+mean the schema/validator has regressed and could admit a malformed manifest."""
+import json, os, sys, glob
+import jsonschema
+try:
+    import yaml
+except Exception:
+    yaml=None
+
+FS="schemas/functional-service.schema.json"
+RM="schemas/repo-maturity.schema.json"
+
+def load(p):
+    if p.endswith((".yaml",".yml")):
+        return None if yaml is None else yaml.safe_load(open(p))
+    return json.load(open(p))
+
+def schema_for(p):
+    b=os.path.basename(p)
+    if b.startswith("functional-service"): return json.load(open(FS))
+    if b.startswith("maturity"): return json.load(open(RM))
+    return None
+
+def main():
+    fixtures=sorted(glob.glob("fixtures/invalid/*"))
+    if not fixtures:
+        print("FAIL: no negative fixtures found under fixtures/invalid/", file=sys.stderr); return 1
+    leaked=0
+    for p in fixtures:
+        s=schema_for(p)
+        if s is None:
+            print(f"  SKIP (no schema mapping): {p}"); continue
+        d=load(p)
+        if d is None:
+            print(f"  SKIP (pyyaml unavailable): {p}"); continue
+        try:
+            jsonschema.validate(d, s)
+            print(f"  FAIL: {p} unexpectedly VALIDATED — schema too loose"); leaked+=1
+        except jsonschema.ValidationError as e:
+            print(f"  OK rejected: {os.path.basename(p)} :: {e.message[:70]}")
+    if leaked:
+        print(f"{leaked} invalid fixture(s) passed validation", file=sys.stderr); return 1
+    print("OK: all negative fixtures correctly rejected"); return 0
+
+if __name__=="__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**M2 → M3 hardening.** Adds negative fixtures the schemas MUST reject, so a malformed manifest can never validate silently, and enforces it in CI.

**New `fixtures/invalid/`:**
- `functional-service.bad-function.json` — `function` outside the canonical enum
- `functional-service.mutable-carry.json` — **`sourceosCarry.carriesMutableModelState: true`** (the critical SourceOS safety invariant)
- `functional-service.missing-schema-version.json` — required field omitted
- `maturity.invalid-level.yaml` — level outside M0–M5
- `maturity.empty-owners.yaml` — empty owners (violates minItems)

**`tools/run_negative_fixtures.py`** validates each against its schema and exits non-zero if any unexpectedly passes. Wired into CI (`Negative fixtures (must be rejected)`) and `make validate-negative`.

Bumps `repo.maturity.yaml` to **M3** (CI-hardened: negative fixtures + enforced CI), target M4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)